### PR TITLE
HOTFIX: Fix GitHub Actions workflow deprecation issues

### DIFF
--- a/.github/workflows/issue-automation.yml
+++ b/.github/workflows/issue-automation.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up PowerShell modules
         shell: pwsh
@@ -52,7 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Automation Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: automation-report
           path: automation-report.md


### PR DESCRIPTION
## Fix GitHub Actions Workflow Deprecation Issues

### Problem
The GitHub Issues Workflow Automation was failing due to using deprecated versions of GitHub Actions:
- `actions/upload-artifact@v3` - deprecated as of April 2024
- `actions/checkout@v3` - should be updated to v4 for consistency

### Solution
Updated the workflow file to use current, supported versions:
- Updated `actions/upload-artifact@v3` → `actions/upload-artifact@v4`
- Updated `actions/checkout@v3` → `actions/checkout@v4`

### Impact
- ✅ Resolves automatic workflow failures in GitHub Issues automation
- ✅ Uses currently supported and maintained action versions
- ✅ No functional changes to workflow behavior
- ✅ Ensures continued reliability of automation systems

### Files Changed
- `.github/workflows/issue-automation.yml`

### Testing
This fix addresses the specific deprecation error that was causing workflows to fail:
```
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`
```

The updated actions are backward compatible and will resolve the failing workflows while maintaining all existing functionality.
